### PR TITLE
Make active power and power meter readings as close as possible so computing consumption values are more accurate

### DIFF
--- a/custom_components/huawei_solar/sensor.py
+++ b/custom_components/huawei_solar/sensor.py
@@ -255,6 +255,10 @@ class HuaweiSolarSensor(Entity):
 
     def update(self):
         self._state = self._inverter.get("active_power").value
+        self._power_meter_active_power = self._inverter.get(
+            "power_meter_active_power"
+        ).value
+        self.input_power = self._inverter.get("input_power").value
         self._daily_yield = self._inverter.get("daily_yield_energy").value
         self._total_yield = self._inverter.get("accumulated_yield_energy").value
         self._reactive_power = self._inverter.get("reactive_power").value
@@ -272,10 +276,6 @@ class HuaweiSolarSensor(Entity):
         self._grid_voltage = self._line_voltage_A_B
         self._grid_current = self._phase_A_current
         self._grid_frequency = self._inverter.get("grid_frequency").value
-        self._power_meter_active_power = self._inverter.get(
-            "power_meter_active_power"
-        ).value
-        self.input_power = self._inverter.get("input_power").value
         self._grid_A_voltage = self._inverter.get("grid_A_voltage").value
         self._grid_B_voltage = self._inverter.get("grid_B_voltage").value
         self._grid_C_voltage = self._inverter.get("grid_C_voltage").value


### PR DESCRIPTION
As power meter provides a variation over the active power and both values should be combined in order to compute the power usage they should be obtained as close in time as possible. As they are in different memory sections it is not possible to retrieve them in a single modbus read so reading it in the following line seems the best workaround to prevent invalid power usage values.

I have other modifications in my fork like providing a prefix option in case you have two inverters of the same model you can prevent their entity name to conflict, i can make a PR for that if you think it may be useful. I have also a reduced attributes option to minimize modbus calls but that is based on my personal needs.

I am also considering passing the power usage and self consumption computations to attributes to the extension instead of making the active power and power meter active power substraction as sensor templates in home assistant but i am not convinced that adding derived values here is the way to go... but it will make users to not care abouut how they should be computed from the data returned by the inverter... what's your opinion?