### PR TITLE
Fix on attribute definition

### DIFF
--- a/custom_components/huawei_solar/sensor.py
+++ b/custom_components/huawei_solar/sensor.py
@@ -212,40 +212,40 @@ class HuaweiSolarSensor(Entity):
             attributes[ATTR_NB_ONLINE_OPTIMIZERS] = self._nb_online_optimizers
 
         if self._battery_installed:
-            attributes[ATTR_STORAGE_STATUS]: self._storage_status
+            attributes[ATTR_STORAGE_STATUS] = self._storage_status
             attributes[
                 ATTR_STORAGE_CHARGE_DISCHARGE_POWER
-            ]: self._storage_charge_discharge_power
+            ] = self._storage_charge_discharge_power
             attributes[
                 ATTR_STORAGE_CURRENT_DAY_CHARGE_CAPACITY
-            ]: self._storage_current_day_charge_capacity
+            ] = self._storage_current_day_charge_capacity
             attributes[
                 ATTR_STORAGE_CURRENT_DAY_DISCHARGE_CAPACITY
-            ]: self._storage_current_day_discharge_capacity
-            attributes[ATTR_STORAGE_WORKING_MODE]: self._storage_working_mode
-            attributes[ATTR_STORAGE_TIME_OF_USE_PRICE]: self._storage_time_of_use_price
-            attributes[ATTR_STORAGE_LCOE]: self._storage_lcoe
+            ] = self._storage_current_day_discharge_capacity
+            attributes[ATTR_STORAGE_WORKING_MODE] = self._storage_working_mode
+            attributes[ATTR_STORAGE_TIME_OF_USE_PRICE] = self._storage_time_of_use_price
+            attributes[ATTR_STORAGE_LCOE] = self._storage_lcoe
             attributes[
                 ATTR_STORAGE_MAXIMUM_CHARGING_POWER
-            ]: self._storage_maximum_charging_power
+            ] = self._storage_maximum_charging_power
             attributes[
                 ATTR_STORAGE_MAXIMUM_DISCHARGING_POWER
-            ]: self._storage_maximum_discharging_power
+            ] = self._storage_maximum_discharging_power
             attributes[
                 ATTR_STORAGE_POWER_LIMIT_GRID_TIED_POINT
-            ]: self._storage_power_limit_grid_tied_point
+            ] = self._storage_power_limit_grid_tied_point
             attributes[
                 ATTR_STORAGE_CHARGING_CUTOFF_CAPACITY
-            ]: self._storage_charging_cutoff_capacity
+            ] = self._storage_charging_cutoff_capacity
             attributes[
                 ATTR_STORAGE_DISCHARGING_CUTOFF_CAPACITY
-            ]: self._storage_discharging_cutoff_capacity
+            ] = self._storage_discharging_cutoff_capacity
             attributes[
                 ATTR_STORAGE_FORCED_CHARGING_AND_DISCHARGING_PERIOD
-            ]: self._storage_forced_charging_and_discharging_period
+            ] = self._storage_forced_charging_and_discharging_period
             attributes[
                 ATTR_STORAGE_FORCED_CHARGING_AND_DISCHARGING_POWER
-            ]: self._storage_forced_charging_and_discharging_power
+            ] = self._storage_forced_charging_and_discharging_power
 
         return attributes
 


### PR DESCRIPTION
I have a new battery installed in one of my inverters and was not able to see the new attributes when enabling the battery option. Was doing some tests until I realized that attribute assignation outside declaration should have been using = instead of :

I have no experience with python so I just realized it by comparing with the optimizers section