### PR TITLE
Use STATE_CLASS_TOTAL_INCREASING value by default and add additional entities

### DIFF
--- a/custom_components/huawei_solar/sensor.py
+++ b/custom_components/huawei_solar/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     PLATFORM_SCHEMA,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -102,10 +103,14 @@ DYNAMIC_ATTR_LIST = [
 
 ATTR_DAILY_YIELD = "daily_yield_energy"
 ATTR_ACCUMULATED_YIELD = "accumulated_yield_energy"
+ATTR_GRID_EXPORTED = "grid_exported_energy"
+ATTR_GRID_ACCUMULATED = "grid_accumulated_energy"
 
 ENTITY_SENSOR_LIST = [
     ATTR_DAILY_YIELD,
     ATTR_ACCUMULATED_YIELD,
+    ATTR_GRID_EXPORTED,
+    ATTR_GRID_ACCUMULATED,
 ]
 
 
@@ -210,8 +215,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             parent_sensor=huawei_solar_sensor,
             register=ATTR_DAILY_YIELD,
             name_prefix="daily_yield",
+            state_class=STATE_CLASS_MEASUREMENT,
         ),
-        HuaweiSolarTotalYieldSensor(
+        HuaweiSolarEntitySensor(
             inverter=inverter,
             unit=ENERGY_KILO_WATT_HOUR,
             icon="mdi:solar-power",
@@ -219,6 +225,24 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             parent_sensor=huawei_solar_sensor,
             register=ATTR_ACCUMULATED_YIELD,
             name_prefix="total_yield",
+        ),
+        HuaweiSolarEntitySensor(
+            inverter=inverter,
+            unit=ENERGY_KILO_WATT_HOUR,
+            icon="mdi:solar-power",
+            device_class=DEVICE_CLASS_ENERGY,
+            parent_sensor=huawei_solar_sensor,
+            register=ATTR_GRID_EXPORTED,
+            name_prefix="grid_exported",
+        ),
+        HuaweiSolarEntitySensor(
+            inverter=inverter,
+            unit=ENERGY_KILO_WATT_HOUR,
+            icon="mdi:solar-power",
+            device_class=DEVICE_CLASS_ENERGY,
+            parent_sensor=huawei_solar_sensor,
+            register=ATTR_GRID_ACCUMULATED,
+            name_prefix="grid_accumulated",
         ),
     ]
 
@@ -233,7 +257,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                     parent_sensor=huawei_solar_sensor,
                     register=ATTR_STORAGE_CHARGE_DISCHARGE_POWER,
                 ),
-                HuaweiSolarTotalYieldSensor(
+                HuaweiSolarEntitySensor(
                     inverter=inverter,
                     unit=ENERGY_KILO_WATT_HOUR,
                     icon="mdi:solar-power",
@@ -241,7 +265,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                     parent_sensor=huawei_solar_sensor,
                     register=ATTR_STORAGE_TOTAL_CHARGE,
                 ),
-                HuaweiSolarTotalYieldSensor(
+                HuaweiSolarEntitySensor(
                     inverter=inverter,
                     unit=ENERGY_KILO_WATT_HOUR,
                     icon="mdi:solar-power",
@@ -422,6 +446,7 @@ class HuaweiSolarEntitySensor(Entity):
         parent_sensor,
         register,
         name_prefix=None,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
     ):
         self._inverter = inverter
         self._hidden = False
@@ -440,6 +465,7 @@ class HuaweiSolarEntitySensor(Entity):
             )
         self._unique_id = self._name
         self._device_class = device_class
+        self._state_class = state_class
 
     @property
     def unique_id(self):
@@ -465,7 +491,7 @@ class HuaweiSolarEntitySensor(Entity):
     @property
     def device_state_attributes(self):
         return {
-            ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+            ATTR_STATE_CLASS: self._state_class,
         }
 
     @property
@@ -496,10 +522,3 @@ class HuaweiSolarDailyYieldSensor(HuaweiSolarEntitySensor):
         }
 
 
-class HuaweiSolarTotalYieldSensor(HuaweiSolarEntitySensor):
-    @property
-    def device_state_attributes(self):
-        return {
-            **super().device_state_attributes,
-            ATTR_LAST_RESET: utc_from_timestamp(0),
-        }


### PR DESCRIPTION
I am making some tests on your new async implementation and made some modifications for myself so I am making this PR with this changes just in case you find any of them useful. 

First of all I have added STATE_CLASS_TOTAL_INCREASING which was added to home assistant in order to manage this kind incremental values to avoid using a fake last_reset attribute with value 0. As daily yield is the only one (if I do not miss anything) that is not working this way I just use the total increasing as default and modified daily yield as an exception.

Also I added two more entities I found missing to use the home assistant energy system (grid export and consumption), as all other (production and battery charge/discharge) are already available

For my case of use I am planning to create a few more entity sensors in my local version like state of capacity, power meter active power and input power to avoid extracting them with templates but they are not included in this PR