### PR TITLE
Support for the "port" parameter in huawei_solar configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Then configure the sensors by setting up the huawei_solar platform in `configura
 | optimizers | boolean | **Optional** | Set to true if you have optimizers and want to see information about them.
 | battery | boolean | **Optional** | Set to true if you have a battery and want to see information about it.
 | slave | int | **Optional** | Set the slave unit, set `slave = 1` when using the dongle.
+| port | int | **Optional** | Set the inverter ModBus TCP port 
 
 **Example:**
 
@@ -30,6 +31,7 @@ sensor:
     optimizers: true
     battery: true
     slave: 1
+    port: 6607
 ```
 
 ## Breaking Changes

--- a/custom_components/huawei_solar/sensor.py
+++ b/custom_components/huawei_solar/sensor.py
@@ -37,6 +37,7 @@ DEFAULT_RECONNECT_INTERVAL = 30
 CONF_OPTIMIZERS = "optimizers"
 CONF_BATTERY = "battery"
 CONF_SLAVE = "slave"
+CONF_PORT = "port"
 
 STATE_REGISTER = "active_power"
 
@@ -148,6 +149,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_OPTIMIZERS, default=False): cv.boolean,
         vol.Optional(CONF_BATTERY, default=False): cv.boolean,
         vol.Optional(CONF_SLAVE, default=0): int,
+        vol.Optional(CONF_PORT, default=502): int,
     }
 )
 
@@ -160,7 +162,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     try:
         inverter = AsyncHuaweiSolar(
-            host=config[CONF_HOST], loop=hass.loop, slave=config[CONF_SLAVE]
+            host=config[CONF_HOST], port=config[CONF_PORT], loop=hass.loop, slave=config[CONF_SLAVE]
         )
 
         for register in STATIC_ATTR_LIST:


### PR DESCRIPTION
In the newest inverter firmware (SPC140) I noticed that default Modbus port has changed from TCP/502 to TCP/6607, and would be great to have an option to configure port number when configuring inverter in huawei_solar section.