### PR TITLE
Fix sensor + change all obsolete consts

### DIFF
--- a/custom_components/huawei_solar/manifest.json
+++ b/custom_components/huawei_solar/manifest.json
@@ -1,9 +1,9 @@
 {
   "domain": "huawei_solar",
   "name": "huawei_solar",
-  "documentation": "https://github.com/Emilv2/huawei_solar",
+  "documentation": "https://github.com/titidnh/huawei_solar",
   "dependencies": [],
   "codeowners": ["Emilv2"],
-  "requirements": ["huawei-solar>=2.0.0,<=2.2.6"],
+  "requirements": ["huawei-solar>=2.0.0,<=2.2.9"],
   "version": "1.2.4"
 }

--- a/custom_components/huawei_solar/manifest.json
+++ b/custom_components/huawei_solar/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "huawei_solar",
   "name": "huawei_solar",
-  "documentation": "https://github.com/titidnh/huawei_solar",
+  "documentation": "https://github.com/Emilv2/huawei_solar",
   "dependencies": [],
   "codeowners": ["Emilv2"],
   "requirements": ["huawei-solar>=2.0.0,<=2.2.9"],

--- a/custom_components/huawei_solar/manifest.json
+++ b/custom_components/huawei_solar/manifest.json
@@ -5,5 +5,5 @@
   "dependencies": [],
   "codeowners": ["Emilv2"],
   "requirements": ["huawei-solar>=2.4.0,<=2.4.5"],
-  "version": "1.2.5"
+  "version": "1.2.6"
 }

--- a/custom_components/huawei_solar/manifest.json
+++ b/custom_components/huawei_solar/manifest.json
@@ -3,7 +3,7 @@
   "name": "huawei_solar",
   "documentation": "https://github.com/Emilv2/huawei_solar",
   "dependencies": [],
-  "codeowners": ["Emilv2"],
-  "requirements": ["huawei-solar>=2.4.0,<=2.4.5"],
-  "version": "1.2.6"
+  "codeowners": ["Emilv2"],    
+  "requirements": [ "huawei-solar==2.4.5" ],
+  "version": "1.2.7"
 }

--- a/custom_components/huawei_solar/manifest.json
+++ b/custom_components/huawei_solar/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/Emilv2/huawei_solar",
   "dependencies": [],
   "codeowners": ["Emilv2"],
-  "requirements": ["huawei-solar>=2.4.5,<=2.4.5"],
+  "requirements": ["huawei-solar>=2.4.0,<=2.4.5"],
   "version": "1.2.5"
 }

--- a/custom_components/huawei_solar/manifest.json
+++ b/custom_components/huawei_solar/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/Emilv2/huawei_solar",
   "dependencies": [],
   "codeowners": ["Emilv2"],
-  "requirements": ["huawei-solar>=2.0.0,<=2.2.9"],
-  "version": "1.2.4"
+  "requirements": ["huawei-solar>=2.4.5,<=2.4.5"],
+  "version": "1.2.5"
 }

--- a/custom_components/huawei_solar/sensor.py
+++ b/custom_components/huawei_solar/sensor.py
@@ -8,8 +8,6 @@ from homeassistant.components.sensor import (
     ATTR_LAST_RESET,
     ATTR_STATE_CLASS,
     PLATFORM_SCHEMA,
-    STATE_CLASS_MEASUREMENT,
-    STATE_CLASS_TOTAL_INCREASING,
     SensorStateClass,
     SensorDeviceClass,
 )

--- a/custom_components/huawei_solar/sensor.py
+++ b/custom_components/huawei_solar/sensor.py
@@ -13,12 +13,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     CONF_HOST,
-    DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_VOLTAGE,
-    ENERGY_KILO_WATT_HOUR,
-    POWER_WATT,
     UnitOfEnergy,
 )
 from homeassistant.helpers.entity import Entity
@@ -219,9 +213,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         huawei_solar_sensor,
         HuaweiSolarDailyYieldSensor(
             inverter=inverter,
-            unit=ENERGY_KILO_WATT_HOUR,
+            unit=UnitOfEnergy.KILO_WATT_HOUR,
             icon="mdi:solar-power",
-            device_class=DEVICE_CLASS_ENERGY,
+            device_class=SensorDeviceClass.ENERGY,
             parent_sensor=huawei_solar_sensor,
             register=ATTR_DAILY_YIELD,
             name_prefix=static_attributes["model_name"] + "_daily_yield",
@@ -229,27 +223,27 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         ),
         HuaweiSolarEntitySensor(
             inverter=inverter,
-            unit=ENERGY_KILO_WATT_HOUR,
+            unit=UnitOfEnergy.KILO_WATT_HOUR,
             icon="mdi:solar-power",
-            device_class=DEVICE_CLASS_ENERGY,
+            device_class=SensorDeviceClass.ENERGY,
             parent_sensor=huawei_solar_sensor,
             register=ATTR_ACCUMULATED_YIELD,
             name_prefix=static_attributes["model_name"] +"_total_yield",
         ),
         HuaweiSolarEntitySensor(
             inverter=inverter,
-            unit=ENERGY_KILO_WATT_HOUR,
+            unit=UnitOfEnergy.KILO_WATT_HOUR,
             icon="mdi:solar-power",
-            device_class=DEVICE_CLASS_ENERGY,
+            device_class=SensorDeviceClass.ENERGY,
             parent_sensor=huawei_solar_sensor,
             register=ATTR_GRID_EXPORTED,
             name_prefix=static_attributes["model_name"] + "_grid_exported",
         ),
         HuaweiSolarEntitySensor(
             inverter=inverter,
-            unit=ENERGY_KILO_WATT_HOUR,
+            unit=UnitOfEnergy.KILO_WATT_HOUR,
             icon="mdi:solar-power",
-            device_class=DEVICE_CLASS_ENERGY,
+            device_class=SensorDeviceClass.ENERGY,
             parent_sensor=huawei_solar_sensor,
             register=ATTR_GRID_ACCUMULATED,
             name_prefix=static_attributes["model_name"] + "_grid_accumulated",
@@ -261,25 +255,25 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             [
                 HuaweiSolarEntitySensor(
                     inverter=inverter,
-                    unit=POWER_WATT,
+                    unit=UnitOfPower.WATT,
                     icon="mdi:solar-power",
-                    device_class=DEVICE_CLASS_POWER,
+                    device_class=SensorDeviceClass.POWER,
                     parent_sensor=huawei_solar_sensor,
                     register=ATTR_STORAGE_CHARGE_DISCHARGE_POWER,
                 ),
                 HuaweiSolarEntitySensor(
                     inverter=inverter,
-                    unit=ENERGY_KILO_WATT_HOUR,
+                    unit=UnitOfEnergy.KILO_WATT_HOUR,
                     icon="mdi:solar-power",
-                    device_class=DEVICE_CLASS_ENERGY,
+                    device_class=SensorDeviceClass.ENERGY,
                     parent_sensor=huawei_solar_sensor,
                     register=ATTR_STORAGE_TOTAL_CHARGE,
                 ),
                 HuaweiSolarEntitySensor(
                     inverter=inverter,
-                    unit=ENERGY_KILO_WATT_HOUR,
+                    unit=UnitOfEnergy.KILO_WATT_HOUR,
                     icon="mdi:solar-power",
-                    device_class=DEVICE_CLASS_ENERGY,
+                    device_class=SensorDeviceClass.ENERGY,
                     parent_sensor=huawei_solar_sensor,
                     register=ATTR_STORAGE_TOTAL_DISCHARGE,
                 ),
@@ -298,7 +292,7 @@ class HuaweiSolarSensor(Entity):
         self._optimizers_installed = optimizers_installed
         self._battery_installed = battery_installed
         self._hidden = False
-        self._unit = POWER_WATT
+        self._unit = UnitOfPower.WATT
         self._icon = "mdi:solar-power"
         self._available = False
         self._state = None
@@ -335,7 +329,7 @@ class HuaweiSolarSensor(Entity):
 
     @property
     def device_class(self):
-        return DEVICE_CLASS_POWER
+        return SensorDeviceClass.POWER
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/huawei_solar/sensor.py
+++ b/custom_components/huawei_solar/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     CONF_HOST,
     UnitOfEnergy,
+    UnitOfPower,
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.dt import utc_from_timestamp

--- a/custom_components/huawei_solar/sensor.py
+++ b/custom_components/huawei_solar/sensor.py
@@ -10,6 +10,8 @@ from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
+    SensorStateClass,
+    SensorDeviceClass,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -19,6 +21,7 @@ from homeassistant.const import (
     DEVICE_CLASS_VOLTAGE,
     ENERGY_KILO_WATT_HOUR,
     POWER_WATT,
+    UnitOfEnergy,
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.dt import utc_from_timestamp
@@ -224,7 +227,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             parent_sensor=huawei_solar_sensor,
             register=ATTR_DAILY_YIELD,
             name_prefix=static_attributes["model_name"] + "_daily_yield",
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=SensorStateClass.MEASUREMENT,
         ),
         HuaweiSolarEntitySensor(
             inverter=inverter,
@@ -455,7 +458,7 @@ class HuaweiSolarEntitySensor(Entity):
         parent_sensor,
         register,
         name_prefix=None,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ):
         self._inverter = inverter
         self._hidden = False


### PR DESCRIPTION
2024-03-10 10:42:49.726 WARNING (MainThread) [homeassistant.setup] Setup of zone is taking over 10 seconds.
2024-03-10 10:42:50.435 WARNING (MainThread) [homeassistant.components.sensor] STATE_CLASS_MEASUREMENT was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.MEASUREMENT instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.446 WARNING (MainThread) [homeassistant.components.sensor] STATE_CLASS_TOTAL_INCREASING was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.TOTAL_INCREASING instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.457 WARNING (MainThread) [homeassistant.components.sensor] STATE_CLASS_MEASUREMENT was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.MEASUREMENT instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.468 WARNING (MainThread) [homeassistant.components.sensor] STATE_CLASS_TOTAL_INCREASING was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorStateClass.TOTAL_INCREASING instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.479 WARNING (MainThread) [homeassistant.const] DEVICE_CLASS_CURRENT was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorDeviceClass.CURRENT instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.490 WARNING (MainThread) [homeassistant.const] DEVICE_CLASS_ENERGY was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorDeviceClass.ENERGY instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.501 WARNING (MainThread) [homeassistant.const] DEVICE_CLASS_POWER was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorDeviceClass.POWER instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.512 WARNING (MainThread) [homeassistant.const] DEVICE_CLASS_VOLTAGE was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use SensorDeviceClass.VOLTAGE instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.524 WARNING (MainThread) [homeassistant.const] ENERGY_KILO_WATT_HOUR was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfEnergy.KILO_WATT_HOUR instead, please report it to the author of the 'huawei_solar' custom integration
2024-03-10 10:42:50.535 WARNING (MainThread) [homeassistant.const] POWER_WATT was used from huawei_solar, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfPower.WATT instead, please report it to the author of the 'huawei_solar' custom integration